### PR TITLE
fixed breaking gaussian_blur import to torchvision.transforms.functional

### DIFF
--- a/notebooks/μNCA_pytorch.ipynb
+++ b/notebooks/μNCA_pytorch.ipynb
@@ -270,7 +270,7 @@
       "source": [
         "# OT loss \n",
         "from geomloss import SamplesLoss\n",
-        "from torchvision.transforms.functional_tensor import gaussian_blur\n",
+        "from torchvision.transforms.functional import gaussian_blur\n",
         "\n",
         "def calc_styles_ot(img, ksize, leveln, show=False):\n",
         "  levels = []\n",


### PR DESCRIPTION
gaussian_blur has been moved to torchvision.transforms.functional. The current import prevents the notebook from running.